### PR TITLE
Fixed Output images in Predicting Multivitamine Purchase

### DIFF
--- a/Prediction Models/Predicting Multivitaimne Purchase/Readme.md
+++ b/Prediction Models/Predicting Multivitaimne Purchase/Readme.md
@@ -17,11 +17,14 @@ The dataset `multivitamins_data.csv` includes various attributes related to cons
 
 ## Outputs:
 -Features of the dataset
+
 ![Figure:1](./Outputs/Screenshot%202024-10-16%20205700.png)
 
 -Pipeline constructed in Microsoft azure
+
 ![Figure:2](./Outputs/Screenshot%202024-10-16%20205710.png)
 
 -Results
+
 ![Figure:3](./Outputs/Screenshot%202024-10-16%20205729.png)
 

--- a/Prediction Models/Predicting Multivitaimne Purchase/Readme.md
+++ b/Prediction Models/Predicting Multivitaimne Purchase/Readme.md
@@ -16,11 +16,12 @@ The dataset `multivitamins_data.csv` includes various attributes related to cons
 - Machine Learning Algorithms
 
 ## Outputs:
-[Figure:1](C:\Users\Harishankar Chiluka\Documents\GitHub\New folder\ML-Nexus\Prediction Models\Predicting Multivitaimne Purchase\Outputs\Screenshot 2024-10-16 205700.png)
--feature of the data
+-Features of the dataset
+![Figure:1](./Outputs/Screenshot%202024-10-16%20205700.png)
 
-[Figure:2](C:\Users\Harishankar Chiluka\Documents\GitHub\New folder\ML-Nexus\Prediction Models\Predicting Multivitaimne Purchase\Outputs\Screenshot 2024-10-16 205710.png)
 -Pipeline constructed in Microsoft azure
+![Figure:2](./Outputs/Screenshot%202024-10-16%20205710.png)
 
-[Figure:3](C:\Users\Harishankar Chiluka\Documents\GitHub\New folder\ML-Nexus\Prediction Models\Predicting Multivitaimne Purchase\Outputs\Screenshot 2024-10-16 205729.png)
 -Results
+![Figure:3](./Outputs/Screenshot%202024-10-16%20205729.png)
+


### PR DESCRIPTION
# Related Issues or bug
Fixes: #412 Output images in Predicting Multivitamine Purchase.
In the Predicting Multivitamin Purchase under the Prediction models, the readme.md file needed to be updated. Under the output section, the links were given which referenced to nowhere.

# Proposed Changes
I have attached the proper images in the output section .

# Screenshots

 Original
![image](https://github.com/user-attachments/assets/62506a30-221f-4fe9-a5fd-dc3c3e8eaca7)

Updated
![image](https://github.com/user-attachments/assets/2df89282-0ed2-4e04-a81e-cfff0e648845)
