### PR TITLE
Added roadmap to learn Deep Learning 

### DIFF
--- a/DEEP_LEARNING_ROADMAP.md
+++ b/DEEP_LEARNING_ROADMAP.md
@@ -1,0 +1,124 @@
+<h1 align="center"><b>🚀 Deep Learning Roadmap</b></h1>
+
+Deep Learning is a subset of Machine Learning that empowers systems to learn from vast amounts of data. Using neural networks, deep learning has led to significant advancements in areas such as computer vision, natural language processing, and speech recognition.
+
+---
+
+## **🔑 Prerequisites**
+
+Before diving into deep learning, you should have a firm grasp on the following concepts:
+
+### 1. **📐 Mathematics for Machine Learning**
+- **Linear Algebra**
+    - Vectors, Matrices, Eigenvalues, and Eigenvectors.
+- **Calculus**
+    - Derivatives, Gradients, Chain Rule, and Partial Derivatives.
+- **Probability and Statistics**
+    - Probability Distributions, Bayes’ Theorem, Statistical Inference.
+
+### 2. **💻 Programming Skills**
+- Proficiency in **Python**, the primary language for deep learning.
+- Familiarity with libraries like **NumPy** and **Pandas** for data manipulation.
+
+### 3. **📊 Machine Learning Fundamentals**
+- Understanding **supervised** and **unsupervised learning**.
+- Knowledge of overfitting, underfitting, and evaluation metrics like accuracy, precision, recall, and F1 score.
+
+---
+
+## **💡 Key Deep Learning Concepts**
+
+### 1. **🧠 Neural Networks**
+- Understanding the structure of a neural network (layers, nodes, activation functions).
+- Learning about **forward propagation** and **backpropagation**.
+- ![Neural Network](https://miro.medium.com/v2/resize:fit:1400/1*SCz0aTETjTYC864Bqjt6Og.png)
+
+### 2. **Types of Neural Networks**
+- **Feedforward Neural Networks (FNN)** 🖼️
+    - Basic neural networks with no feedback loop.
+- **Convolutional Neural Networks (CNN)** 🖼️
+    - Used in image processing tasks like **image classification** and **object detection**.
+    - ![CNN](https://upload.wikimedia.org/wikipedia/commons/6/63/Typical_cnn.png)
+- **Recurrent Neural Networks (RNN)** 🖼️
+    - Best for sequence data like time series and text.
+    - ![RNN](https://miro.medium.com/v2/resize:fit:1400/1*5bjD7kmtaJI-n3qztBC2Ig.png)
+- **Long Short-Term Memory Networks (LSTM)** 🖼️
+    - A specialized form of RNN designed to handle long-range dependencies.
+
+### 3. **Deep Learning Frameworks**
+- **TensorFlow** 🐍 [[Link]](https://www.tensorflow.org/)
+    - An open-source machine learning platform.
+- **PyTorch** 🔥 [[Link]](https://pytorch.org/)
+    - A dynamic deep learning library loved by researchers.
+
+---
+
+## **🛠️ Techniques in Deep Learning**
+
+### 1. **Regularization Techniques**
+- **Dropout**: Randomly drops neurons during training to prevent overfitting.
+    - ![Dropout](https://miro.medium.com/v2/resize:fit:1400/1*jR3TvRFg7TyTeioDRqoywA.png)
+- **Batch Normalization**: Normalizes inputs to layers within the network to stabilize training and improve speed.
+
+### 2. **Model Optimization**
+- Understand key optimization algorithms:
+    - **Stochastic Gradient Descent (SGD)** ✏️
+    - **Adam Optimizer** 🧮
+    - **RMSProp**
+- Tuning hyperparameters using **Grid Search** or **Random Search**.
+
+---
+
+## **🧑‍🏫 Advanced Topics**
+
+### 1. **Transfer Learning**
+- Fine-tuning pre-trained models like **ResNet**, **VGG**, and **BERT** for new tasks with limited data.
+- ![Transfer Learning](https://miro.medium.com/v2/resize:fit:1000/1*9xgMViGHMKUX6Ir4_ZcoKg.png)
+
+### 2. **Autoencoders**
+- A type of neural network used to learn efficient representations of data, typically for the purpose of **dimensionality reduction**.
+    - ![Autoencoder](https://miro.medium.com/v2/resize:fit:600/1*nqzWupxC60iAH2dYrFT78Q.png)
+
+### 3. **Generative Adversarial Networks (GANs)**
+- Used for generating new data samples that resemble the training data. GANs have been used for **image generation**, **super-resolution**, and **style transfer**.
+    - ![GANs](https://editor.analyticsvidhya.com/uploads/68249components_of_GAN.jfif)
+
+---
+
+## **📚 Resources to Learn Deep Learning**
+
+### **Books**
+- **"Deep Learning" by Ian Goodfellow, Yoshua Bengio, and Aaron Courville** [[Link]](https://www.deeplearningbook.org/)
+- **"Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow" by Aurélien Géron** [[Link]](https://www.oreilly.com/library/view/hands-on-machine-learning/9781492032632/)
+
+### **Online Courses**
+- **Deep Learning Specialization by Andrew Ng** [[Link]](https://www.coursera.org/specializations/deep-learning)
+- **Fast.ai Course** [[Link]](https://course.fast.ai/)
+
+### **Communities and Forums**
+- **Kaggle**: Join competitions and engage with other learners [[Link]](https://www.kaggle.com/)
+- **Deep Learning Reddit Community**: Stay updated with the latest research and trends [[Link]](https://www.reddit.com/r/deeplearning/)
+
+---
+
+## **🌍 Applications of Deep Learning**
+
+### 1. **Computer Vision** 🖼️
+- Tasks like **image classification**, **object detection**, and **segmentation**.
+- Example: Self-driving cars, facial recognition systems.
+
+### 2. **Natural Language Processing (NLP)** 🗣️
+- Tasks like **sentiment analysis**, **text generation**, and **language translation**.
+- Example: Virtual assistants, machine translation systems.
+
+### 3. **Speech Recognition** 🎤
+- Converting spoken language into text.
+- Example: Google Assistant, Alexa, and Siri.
+
+---
+
+## **🔗 Conclusion**
+
+Deep learning is a rapidly evolving field with immense potential in various industries. By following this roadmap, you will build a strong foundation in deep learning concepts and techniques. Keep learning, experimenting, and contributing to the community!
+
+<p align="center"><img src="https://www.researchgate.net/publication/351150323/figure/fig3/AS:1023064154333186@1620928910961/Deep-learning-models-Schematic-illustration-of-the-neural-networks-described-in-Section.ppm" alt="Deep Learning Illustration" /></p>

--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ This guide covers:
 
 <br>
 
+## 📚 Deep Learning Roadmap
+
+To get an in-depth overview and roadmap to learn Deep Learning, check out [Deep Learning Roadmap.](DEEP_LEARNING_ROADMAP.md)
+
+This guide covers:
+
+- Overview of deep learning
+- Roadmap to learn deep learning
+- Types of neural networks 🧠
+- Key deep learning concepts
+- Regularization techniques 💡
+- Model optimization 🔧
+- Transfer learning 🚀
+- Deep learning applications 📷📝🔊
+- Best practices and resources
+
+<br>
+
 ## ⭐ How to get started with open source?
 <img src="https://github.com/Vi1234sh12/Face-X/blob/master/.github/Assests/isometric.png" height="290px" align="right"/>
 


### PR DESCRIPTION
# Related Issues or bug
Fixes the issue : Feature request : Create a Learning Roadmap for Deep Learning #494

Fixes: #494  

# Proposed Changes

- I have made the following changes listed below:

  - **Created `GENERATIVE_AI_ROADMAP.md` file:**
    - Overview of Generative AI
    - Roadmap to learn Generative AI
    - Python libraries to learn Generative AI
    - LLM models and examples
    - Retrieval Augmented Generation (RAG)
    - Embedding models
    - Vector databases
    - Graph databases
    - AI agents
    - PDF scraping tools and services

  - **Changes in `README.md` file:**
    - Added reference to the new `GENERATIVE_AI_ROADMAP.md` file for better navigation.
  
# Screenshots

 Original          
![image](https://github.com/user-attachments/assets/1bb7f4b0-cbe9-420c-b6cd-f47b156f81db)

 Updated
![image](https://github.com/user-attachments/assets/8436e1d8-209b-4349-bd28-37f6a509a932)
![image](https://github.com/user-attachments/assets/c9783cb2-64df-47bb-a6a3-3246bf9daba7)


